### PR TITLE
fix(content): 避免复制时触发剪贴板读取权限

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -544,6 +544,33 @@ function getConfig(key) {
 	return configCache[key]
 }
 
+function getSelectedText() {
+	const activeElement = document.activeElement
+
+	if (activeElement) {
+		const tagName = activeElement.tagName
+		const inputType = (activeElement.type || 'text').toLowerCase()
+		const canReadSelection =
+			tagName === 'TEXTAREA' || (tagName === 'INPUT' && ['text', 'search', 'url', 'email', 'tel'].includes(inputType))
+
+		if (canReadSelection && typeof activeElement.selectionStart === 'number' && typeof activeElement.selectionEnd === 'number') {
+			return activeElement.value.slice(activeElement.selectionStart, activeElement.selectionEnd).trim()
+		}
+	}
+
+	return window.getSelection()?.toString().trim() || ''
+}
+
+function detectOfflineLink(text) {
+	if (/^magnet:\?xt=urn:[a-z0-9]+:[a-z0-9]{32,}/i.test(text)) {
+		return { url: text, type: 'Magnet' }
+	}
+	if (/^ed2k:\/\/\|file\|/i.test(text)) {
+		return { url: text, type: 'ED2K' }
+	}
+	return null
+}
+
 function getRootLabel() {
 	return t('root_path_name')
 }
@@ -882,30 +909,12 @@ async function init() {
 		}
 	})
 
-	// Copy event listener - detect magnet/ed2k links in clipboard
+	// Copy event listener - detect magnet/ed2k links from the current selection
 	document.addEventListener('copy', () => {
-		setTimeout(async () => {
-			try {
-				const text = await navigator.clipboard.readText()
-				const trimmed = text.trim()
-				if (/^magnet:\?xt=urn:[a-z0-9]+:[a-z0-9]{32,}/i.test(trimmed)) {
-					createConfirmModal(trimmed, 'Magnet')
-				} else if (/^ed2k:\/\/\|file\|/i.test(trimmed)) {
-					createConfirmModal(trimmed, 'ED2K')
-				}
-			} catch (e) {
-				// Clipboard API failed, try selection
-				const selection = window.getSelection()
-				if (selection) {
-					const text = selection.toString().trim()
-					if (/^magnet:\?xt=urn:[a-z0-9]+:[a-z0-9]{32,}/i.test(text)) {
-						createConfirmModal(text, 'Magnet')
-					} else if (/^ed2k:\/\/\|file\|/i.test(text)) {
-						createConfirmModal(text, 'ED2K')
-					}
-				}
-			}
-		}, 100)
+		if (!getConfig(CONFIG_KEYS.AUTO_DETECT)) return
+
+		const link = detectOfflineLink(getSelectedText())
+		if (link) createConfirmModal(link.url, link.type)
 	})
 
 	// Listen for config changes


### PR DESCRIPTION
## 概述

- 移除全局 `copy` 监听器中的 `navigator.clipboard.readText()`。
- 改为从当前文本选区检测 magnet/ed2k 链接，不再读取系统剪贴板。
- 在 `copy` 监听器里增加 `AUTO_DETECT` 判断，避免已经注入到页面中的 content script 在关闭自动识别后仍继续响应复制事件。

## 原因

之前的实现会在每次复制事件触发后先读取系统剪贴板，再判断复制内容是否为 magnet/ed2k 链接。

在 Chromium 浏览器中，这会导致任意网页上复制普通文本时也可能弹出剪贴板读取权限提示，并且提示会显示为当前网页域名正在请求读取剪贴板。

改为读取当前选区后，可以保留复制 magnet/ed2k 链接时自动识别的行为，同时避免触发剪贴板读取权限提示。

## 验证

- `node --check extension/content.js`
- `git diff --check`
- 确认 `extension/content.js` 中不再出现 `navigator.clipboard` / `readText`